### PR TITLE
Requests Should Fail Fast

### DIFF
--- a/descarteslabs/__init__.py
+++ b/descarteslabs/__init__.py
@@ -14,7 +14,7 @@
 
 # flake8: noqa
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 from .auth import Auth
 descartes_auth = Auth()
 

--- a/descarteslabs/__init__.py
+++ b/descarteslabs/__init__.py
@@ -14,7 +14,7 @@
 
 # flake8: noqa
 
-__version__ = "0.3.0"
+__version__ = "0.3.0-dev"
 from .auth import Auth
 descartes_auth = Auth()
 

--- a/descarteslabs/services/metadata.py
+++ b/descarteslabs/services/metadata.py
@@ -20,7 +20,7 @@ from .places import Places
 
 
 class Metadata(Service):
-    TIMEOUT = 120
+    TIMEOUT = (9.5, 120)
     """Image Metadata Service https://iam.descarteslabs.com/service/runcible"""
 
     def __init__(self, url=None, token=None):

--- a/descarteslabs/services/places.py
+++ b/descarteslabs/services/places.py
@@ -21,7 +21,7 @@ from .service import Service
 
 
 class Places(Service):
-    TIMEOUT = 120
+    TIMEOUT = (9.5, 120)
     """Places and statistics service https://iam.descarteslabs.com/service/waldo"""
 
     def __init__(self, url=None, token=None, maxsize=10, ttl=600):

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -26,7 +26,7 @@ from .places import Places
 
 class Raster(Service):
     """Raster"""
-    TIMEOUT = 300
+    TIMEOUT = (9.5, 300)
 
     def __init__(self, url=None, token=None):
         """The parent Service class implements authentication and exponential

--- a/descarteslabs/services/service.py
+++ b/descarteslabs/services/service.py
@@ -38,7 +38,7 @@ class WrappedSession(requests.Session):
 
 
 class Service:
-    TIMEOUT = 30
+    TIMEOUT = (9.5, 30)
 
     def __init__(self, url, token):
         self.auth = descartes_auth

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import os
 from setuptools import setup, find_packages
 
 
-__version__ = "0.2.2"
+__version__ = "0.3.0-dev"
 
 
 def do_setup():


### PR DESCRIPTION
The timeout for Python Requests can take a tuple that allows the separation of the connect and read timeouts. Read more here: http://docs.python-requests.org/en/master/user/advanced/#timeouts

Not sure on when we want to add this as it is not really a bug or a feature.