### PR TITLE
Fix docs inconsistency between outsize and 'dimensions'.

### DIFF
--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -258,8 +258,10 @@ class Raster(Service):
         :param str output_format: Output format (`GTiff`, `PNG`, ...).
         :param str data_type: Output data type (`Byte`, `UInt8`, `UInt16`, `Float32`, etc).
         :param str srs: Output spatial reference system definition understood by GDAL.
-        :param float resolution: Desired resolution in output SRS units.
-        :param tuple outsize: Desired output (width, height) in pixels.
+        :param float resolution: Desired resolution in output SRS units. Incompatible with
+            `dimensions`
+        :param tuple dimensions: Desired output (width, height) in pixels. Incompatible with
+            `resolution`
         :param str cutline: A GeoJSON feature or geometry to be used as a cutline.
         :param str place: A slug identifier to be used as a cutline.
         :param tuple bounds: ``(min_x, min_y, max_x, max_y)`` in target SRS.
@@ -324,8 +326,27 @@ class Raster(Service):
     ):
         """Retrieve a raster as a NumPy array.
 
-        See :meth:`raster` for more information.
-
+        :param inputs: List of :class:`Metadata` identifiers.
+        :param bands: List of requested bands.
+        :param scales: List of tuples specifying the scaling to be applied to each band.
+            If no scaling is desired for a band, use ``None`` where appropriate. If a
+            tuple contains four elements, the last two will be used as the output range.
+            For example, ``(0, 10000, 0, 128)`` would scale the source values 0-10000 to
+            be returned as 0-128 in the output.
+        :param str data_type: Output data type (`Byte`, `UInt8`, `UInt16`, `Float32`, etc).
+        :param str srs: Output spatial reference system definition understood by GDAL.
+        :param float resolution: Desired resolution in output SRS units. Incompatible with
+            `dimensions`
+        :param tuple dimensions: Desired output (width, height) in pixels. Incompatible with
+            `resolution`
+        :param str cutline: A GeoJSON feature or geometry to be used as a cutline.
+        :param str place: A slug identifier to be used as a cutline.
+        :param tuple bounds: ``(min_x, min_y, max_x, max_y)`` in target SRS.
+        :param str bounds_srs: Override the coordinate system in which bounds are expressed.
+        :param bool align_pixels: Align pixels to the target coordinate system.
+        :param str resampler: Resampling algorithm to be used during warping (``near``,
+            ``bilinear``, ``cubic``, ``cubicsplice``, ``lanczos``, ``average``, ``mode``,
+            ``max``, ``min``, ``med``, ``q1``, ``q3``).
         :param str order: Order of the returned array. `image` returns arrays as
             ``(row, column, band)`` while `gdal` returns arrays as ``(band, row, column)``.
 


### PR DESCRIPTION
Also just explicitly fill in ndarray docs copying from .raster.