### PR TITLE
removed extra words, fixed spelling

### DIFF
--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:13426c63d2084ead374da3bb134285e1fe50ccdb2135dfea4e851ecef9e092dc
-size 4370826
+oid sha256:237615dcee9aa73c44aa29812784e91f22a78f7b6b9190a62021fce6269b442d
+size 4984303


### PR DESCRIPTION
It might be hard to see the diff with the file stored in Git LFS, but it's two small changes in `docs/getting_started.ipynb`.

> So you have now have access to a giant archive of imagery.
to
> So you now have access to a giant archive of imagery.


> ... mechanisims to find shapes of known places.
to
> ...mechanisms to find shapes of known places.
