### PR TITLE
Handle 404 HTTP errors explicitly with an explicit exception

### DIFF
--- a/descarteslabs/exceptions.py
+++ b/descarteslabs/exceptions.py
@@ -19,5 +19,9 @@ class BadRequestError(ServerError):
     status = 400
 
 
+class NotFoundError(ServerError):
+    status = 404
+
+
 class RateLimitError(ServerError):
     status = 429

--- a/descarteslabs/services/service.py
+++ b/descarteslabs/services/service.py
@@ -20,7 +20,7 @@ from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
 from descarteslabs import descartes_auth
-from descarteslabs.exceptions import ServerError, BadRequestError, RateLimitError
+from descarteslabs.exceptions import ServerError, BadRequestError, NotFoundError, RateLimitError
 
 
 class WrappedSession(requests.Session):
@@ -31,6 +31,8 @@ class WrappedSession(requests.Session):
             return resp
         elif resp.status_code == 400:
             raise BadRequestError(resp.text)
+        elif resp.status_code == 404:
+            raise NotFoundError(resp.text)
         elif resp.status_code == 429:
             raise RateLimitError(resp.text)
         else:


### PR DESCRIPTION
Previously these were handled generically as ServerErrors which is
a bit opaque as a user of the library, especially when looking up
shapes.

Fixes #101