### PR TITLE
Fix broken Metadata.features implementation

### DIFF
--- a/descarteslabs/services/metadata.py
+++ b/descarteslabs/services/metadata.py
@@ -296,32 +296,30 @@ class Metadata(Service):
 
         :return: Generator of GeoJSON ``Feature`` objects.
         """
-        result = self.summary(sat_id=sat_id, const_id=const_id, date=date,
+        summary = self.summary(sat_id=sat_id, const_id=const_id, date=date,
                               place=place, geom=geom, start_time=start_time,
                               end_time=end_time, cloud_fraction=cloud_fraction,
                               cloud_fraction_0=cloud_fraction_0, fill_fraction=fill_fraction,
                               params=params, bbox=bbox)
 
-        for summary in result:
+        offset = 0
 
-            offset = 0
+        count = summary['count']
 
-            count = summary['count']
+        while offset < count:
 
-            while offset < count:
+            features = self.search(sat_id=sat_id, const_id=const_id,
+                                   date=date, place=place, geom=geom,
+                                   start_time=start_time, end_time=end_time,
+                                   cloud_fraction=cloud_fraction,
+                                   cloud_fraction_0=cloud_fraction_0,
+                                   fill_fraction=fill_fraction, params=params,
+                                   limit=limit, offset=offset, bbox=bbox)
 
-                features = self.search(sat_id=sat_id, const_id=const_id,
-                                       date=date, place=place, geom=geom,
-                                       start_time=start_time, end_time=end_time,
-                                       cloud_fraction=cloud_fraction,
-                                       cloud_fraction_0=cloud_fraction_0,
-                                       fill_fraction=fill_fraction, params=params,
-                                       limit=limit, offset=offset, bbox=bbox)
+            offset = limit + offset
 
-                offset = limit + offset
-
-                for feature in features['features']:
-                    yield feature
+            for feature in features['features']:
+                yield feature
 
     def get(self, key):
         """Get metadata of a single image.

--- a/descarteslabs/services/metadata.py
+++ b/descarteslabs/services/metadata.py
@@ -297,10 +297,10 @@ class Metadata(Service):
         :return: Generator of GeoJSON ``Feature`` objects.
         """
         summary = self.summary(sat_id=sat_id, const_id=const_id, date=date,
-                              place=place, geom=geom, start_time=start_time,
-                              end_time=end_time, cloud_fraction=cloud_fraction,
-                              cloud_fraction_0=cloud_fraction_0, fill_fraction=fill_fraction,
-                              params=params, bbox=bbox)
+                               place=place, geom=geom, start_time=start_time,
+                               end_time=end_time, cloud_fraction=cloud_fraction,
+                               cloud_fraction_0=cloud_fraction_0, fill_fraction=fill_fraction,
+                               params=params, bbox=bbox)
 
         offset = 0
 

--- a/descarteslabs/tests/test_metadata.py
+++ b/descarteslabs/tests/test_metadata.py
@@ -83,6 +83,5 @@ class TestMetadata(unittest.TestCase):
         self.assertGreater(len(list(first_21)), 0)
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/descarteslabs/tests/test_metadata.py
+++ b/descarteslabs/tests/test_metadata.py
@@ -76,6 +76,12 @@ class TestMetadata(unittest.TestCase):
         self.assertIn('items', r)
         self.assertEqual(len(r['items']), 1)
 
+    def test_features(self):
+        r = self.instance.features(start_time='2016-07-06', end_time='2016-07-07', sat_id='LANDSAT_8',
+                                 place='europe', limit=20)
+        self.assertGreater(len(list(r)), 0)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/descarteslabs/tests/test_metadata.py
+++ b/descarteslabs/tests/test_metadata.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
 import unittest
 
 import descarteslabs as dl
@@ -77,9 +78,9 @@ class TestMetadata(unittest.TestCase):
         self.assertEqual(len(r['items']), 1)
 
     def test_features(self):
-        r = self.instance.features(start_time='2016-07-06', end_time='2016-07-07', sat_id='LANDSAT_8',
-                                 place='europe', limit=20)
-        self.assertGreater(len(list(r)), 0)
+        r = self.instance.features(start_time='2016-07-06', end_time='2016-07-07', sat_id='LANDSAT_8', limit=20)
+        first_21 = itertools.islice(r, 21)
+        self.assertGreater(len(list(first_21)), 0)
 
 
 


### PR DESCRIPTION
This was always throwing an exception since it was likely
implemented against an older version of the API