### PR TITLE
Make land cover notebook run with recent library versions

### DIFF
--- a/docs/land_cover_demo.ipynb
+++ b/docs/land_cover_demo.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f6dc6f44635eea9f87382ae8082b86954d207cbea06a8e8ab8303704b803dd37
-size 750096
+oid sha256:e0bd45d29d4eccadb4c3d48566465413e507dd0cf507a5333d618e750f31e60b
+size 749478


### PR DESCRIPTION
The feature list from a metadata search result wasn't referenced
correctly. Also clean up a lot of unused imports.

Manual diff because of LFS:

```
23,26d22
<     "from IPython.display import display, Image\n",
<     "\n",
<     "%matplotlib inline\n",
<     "import matplotlib.pyplot as plt\n",
29,32d24
<     "from descarteslabs.services import Places\n",
<     "from descarteslabs.services import Metadata\n",
<     "places = Places()\n",
<     "metadata = Metadata()\n",
38,43d29
<     "\n",
<     "import csv\n",
<     "import os\n",
<     "import subprocess\n",
<     "import random\n",
<     "import json\n",
45,51d30
<     "import gdal\n",
<     "import ogr, osr \n",
<     "import osgeo\n",
<     "from datetime import datetime\n",
<     "import shapely\n",
<     "from shapely import geometry\n",
<     "from shapely.geometry import shape, mapping\n",
157c136
<     "mato_grosso = places.shape('south-america_brazil_mato-grosso')\n",
---
>     "mato_grosso = dl.places.shape('south-america_brazil_mato-grosso')\n",
203c182
<     "images = metadata.search(\n",
---
>     "images = dl.metadata.search(\n",
207c186
<     "                                geom=json.dumps(dltile['geometry']),\n",
---
>     "                                geom=dltile['geometry'],\n",
213c192
<     "n_images = len(images)\n",
---
>     "n_images = len(images['features'])\n",
265c244
<     "for feature in images:\n",
---
>     "for feature in images['features']:\n",
```