### PR TITLE
Save raster to file

### DIFF
--- a/descarteslabs/scripts/parser/__init__.py
+++ b/descarteslabs/scripts/parser/__init__.py
@@ -74,6 +74,7 @@ raster_parser.add_argument("-output_format", default='GTiff', type=str)
 raster_parser.add_argument("-data_type", default='UInt16', type=str)
 raster_parser.add_argument("-srs", default=None, type=str)
 raster_parser.add_argument("-place", default=None, type=str)
+raster_parser.add_argument("-outfile_basename", default=None, type=str)
 
 
 def handle(args):

--- a/descarteslabs/scripts/parser/raster.py
+++ b/descarteslabs/scripts/parser/raster.py
@@ -53,7 +53,7 @@ def raster_handler(args):
         if args.outfile_basename:
             outfilename = args.outfile_basename + os.path.splitext(filename)[1]
         else:
-            outfilename = args.outfile_basename
+            outfilename = filename
         with open(outfilename, "wb") as f:
             f.write(data)
     print(json.dumps(response['metadata'], indent=2))

--- a/descarteslabs/scripts/parser/raster.py
+++ b/descarteslabs/scripts/parser/raster.py
@@ -14,11 +14,9 @@
 # limitations under the License.
 
 from __future__ import print_function
-import os
 import argparse
 import json
 import descarteslabs as dl
-import six
 
 
 def scales(s):

--- a/descarteslabs/scripts/parser/raster.py
+++ b/descarteslabs/scripts/parser/raster.py
@@ -47,13 +47,8 @@ def raster_handler(args):
         'output_format': args.output_format,
         'srs': args.srs,
         'place': args.place,
+        'save': True,
+        'outfile_basename': args.outfile_basename,
     }
     response = dl.raster.raster(**params)
-    for filename, data in six.iteritems(response['files']):
-        if args.outfile_basename:
-            outfilename = args.outfile_basename + os.path.splitext(filename)[1]
-        else:
-            outfilename = filename
-        with open(outfilename, "wb") as f:
-            f.write(data)
     print(json.dumps(response['metadata'], indent=2))

--- a/descarteslabs/scripts/parser/raster.py
+++ b/descarteslabs/scripts/parser/raster.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from __future__ import print_function
+import os
 import argparse
 import json
 import descarteslabs as dl
@@ -49,6 +50,10 @@ def raster_handler(args):
     }
     response = dl.raster.raster(**params)
     for filename, data in six.iteritems(response['files']):
-        with open(filename, "wb") as f:
+        if args.outfile_basename:
+            outfilename = args.outfile_basename + os.path.splitext(filename)[1]
+        else:
+            outfilename = args.outfile_basename
+        with open(outfilename, "wb") as f:
             f.write(data)
     print(json.dumps(response['metadata'], indent=2))

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -314,9 +314,9 @@ class Raster(Service):
         if save:
             for filename, data in six.iteritems(json_resp['files']):
                 if outfile_basename:
-                    outfilename = args.outfile_basename + os.path.splitext(filename)[1]
+                    outfilename = outfile_basename + os.path.splitext(filename)[1]
                 else:
-                    outfilename = args.outfile_basename
+                    outfilename = outfile_basename
                 with open(outfilename, "wb") as f:
                     f.write(data)
 

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -309,15 +309,19 @@ class Raster(Service):
         json_resp = r.json()
         # Decode base64
         for k in json_resp['files'].keys():
-            json_resp['files'][k] = base64.b64decode(json_resp['files'][k])
+            if outfile_basename:
+                outfilename = "{}.{}".format(
+                    outfile_basename,
+                    ".".join(os.path.basename(k).split(".")[1:])
+                )
+                print "outfilename: {}".format(outfilename)
+            else:
+                outfilename = k
+            json_resp['files'][outfilename] = base64.b64decode(json_resp['files'][k])
 
         if save:
             for filename, data in six.iteritems(json_resp['files']):
-                if outfile_basename:
-                    outfilename = outfile_basename + os.path.splitext(filename)[1]
-                else:
-                    outfilename = filename
-                with open(outfilename, "wb") as f:
+                with open(filename, "wb") as f:
                     f.write(data)
 
         return json_resp

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -316,7 +316,9 @@ class Raster(Service):
                 )
             else:
                 outfilename = k
-            json_resp['files'][outfilename] = base64.b64decode(json_resp['files'][k])
+            json_resp['files'][outfilename] = base64.b64decode(
+                json_resp['files'].pop(k)
+            )
 
         if save:
             for filename, data in six.iteritems(json_resp['files']):

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -308,7 +308,7 @@ class Raster(Service):
 
         json_resp = r.json()
         # Decode base64
-        for k in json_resp['files'].keys():
+        for k in list(json_resp['files'].keys()):
             if outfile_basename:
                 outfilename = "{}.{}".format(
                     outfile_basename,

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -22,6 +22,7 @@ from descarteslabs.addons import numpy as np
 from descarteslabs.utilities import as_json_string
 from .service import Service
 from .places import Places
+import six
 
 
 class Raster(Service):
@@ -244,6 +245,8 @@ class Raster(Service):
             place=None,
             align_pixels=False,
             resampler=None,
+            save=False,
+            outfile_basename=None,
     ):
         """Given a list of :class:`Metadata <descarteslabs.services.Metadata>` identifiers,
         retrieve a translated and warped mosaic.
@@ -270,6 +273,9 @@ class Raster(Service):
         :param str resampler: Resampling algorithm to be used during warping (``near``,
             ``bilinear``, ``cubic``, ``cubicsplice``, ``lanczos``, ``average``, ``mode``,
             ``max``, ``min``, ``med``, ``q1``, ``q3``).
+        :param bool save: Write resulting files to disk. Default: False
+        :param str outfile_basename: If 'save' is True, override default filename using
+            this string as a base.
         """
         cutline = as_json_string(cutline)
 
@@ -304,6 +310,15 @@ class Raster(Service):
         # Decode base64
         for k in json_resp['files'].keys():
             json_resp['files'][k] = base64.b64decode(json_resp['files'][k])
+
+        if save:
+            for filename, data in six.iteritems(json_resp['files']):
+                if outfile_basename:
+                    outfilename = args.outfile_basename + os.path.splitext(filename)[1]
+                else:
+                    outfilename = args.outfile_basename
+                with open(outfilename, "wb") as f:
+                    f.write(data)
 
         return json_resp
 

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -316,7 +316,7 @@ class Raster(Service):
                 if outfile_basename:
                     outfilename = outfile_basename + os.path.splitext(filename)[1]
                 else:
-                    outfilename = outfile_basename
+                    outfilename = filename
                 with open(outfilename, "wb") as f:
                     f.write(data)
 

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -314,7 +314,6 @@ class Raster(Service):
                     outfile_basename,
                     ".".join(os.path.basename(k).split(".")[1:])
                 )
-                print "outfilename: {}".format(outfilename)
             else:
                 outfilename = k
             json_resp['files'][outfilename] = base64.b64decode(json_resp['files'][k])

--- a/descarteslabs/tests/test_raster.py
+++ b/descarteslabs/tests/test_raster.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
+import shutil
 import unittest
 import json
 
@@ -38,6 +41,25 @@ class TestRaster(unittest.TestCase):
         self.assertTrue("files" in r)
         self.assertTrue("meta_LC80270312016188_v1_red-green-blue-alpha.tif" in r['files'])
         self.assertIsNotNone(r['files']['meta_LC80270312016188_v1_red-green-blue-alpha.tif'])
+
+    def test_raster_save(self):
+        tmpdir = tempfile.mkdtemp()
+        try:
+            response = self.raster.raster(
+                inputs=['meta_LC80270312016188_v1'],
+                bands=['red', 'green', 'blue', 'alpha'],
+                resolution=960, save=True,
+                outfile_basename="{}/my-raster".format(tmpdir)
+            )
+            with open("{}/my-raster.tif".format(tmpdir), "rb") as f:
+                f.seek(0, os.SEEK_END)
+                length = f.tell()
+            self.assertEqual(
+                length,
+                len(response['files']["{}/my-raster.tif".format(tmpdir)])
+            )
+        finally:
+            shutil.rmtree(tmpdir)
 
     def test_ndarray(self):
         try:


### PR DESCRIPTION
Optionally save raster from dl.raster.raster call, and add command line option to override default filename.
