### PR TITLE
subclass dict and override repr method for raster responses.

### DIFF
--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -19,7 +19,7 @@ import json
 import warnings
 
 from descarteslabs.addons import numpy as np
-from descarteslabs.utilities import as_json_string
+from descarteslabs.utilities import as_json_string, RasterResponse
 from .service import Service
 from .places import Places
 import six
@@ -314,7 +314,7 @@ class Raster(Service):
         if r.status_code != 200:
             raise RuntimeError("%s: %s" % (r.status_code, r.text))
 
-        json_resp = r.json()
+        json_resp = RasterResponse(r.json())
         # Decode base64
         for k in list(json_resp['files'].keys()):
             if outfile_basename:

--- a/descarteslabs/tests/test_raster.py
+++ b/descarteslabs/tests/test_raster.py
@@ -211,3 +211,16 @@ class TestRaster(unittest.TestCase):
     def test_dlkey(self):
         dlkey_geojson = self.raster.dlkey("2048:16:30.0:16:-4:81")
         self.assertEqual(dlkey_geojson['properties']['key'], "2048:16:30.0:16:-4:81")
+
+    def test_raster_repr(self):
+        scene = dl.raster.raster(
+            inputs=['meta_LC80270312016188_v1'],
+            resolution=860,
+        )
+        self.assertEqual(
+                repr(scene), '<{} {} object at {}>'.format(
+                    scene.__module__,
+                    scene.__class__.__name__,
+                    hex(id(scene))
+                )
+            )

--- a/descarteslabs/utilities.py
+++ b/descarteslabs/utilities.py
@@ -22,3 +22,16 @@ def as_json_string(str_or_dict):
         return json.dumps(str_or_dict)
     else:
         return str_or_dict
+
+
+class RasterResponse(dict):
+    """Represent a :meth: descarteslabs.raster.raster response
+    with a sensible command line representation.
+    """
+
+    def __repr__(self):
+        return '<{} {} object at {}>'.format(
+                    self.__module__,
+                    self.__class__.__name__,
+                    hex(id(self))
+                )


### PR DESCRIPTION
Is the minimal repr okay or should we include some more info about the raster? It seems like the conventional forms are either `eval`able strings or minmal object descriptions.