### PR TITLE
Add .gitconfig to ignore lfs files

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[filter "lfs"]
+	smudge = git-lfs smudge --skip %f


### PR DESCRIPTION
Skips all lfs files during git clone/pull (which ignores the ipython notebooks). Notebooks can still be retrieved with `git lfs pull`. Improves install/download/clone time for the client library considerably.