### PR TITLE
remove retry on 429

### DIFF
--- a/descarteslabs/services/service.py
+++ b/descarteslabs/services/service.py
@@ -61,7 +61,7 @@ class Service:
                              'HEAD', 'TRACE', 'GET', 'POST',
                              'PUT', 'OPTIONS', 'DELETE'
                          ]),
-                         status_forcelist=[429, 500, 502, 503])
+                         status_forcelist=[500, 502, 503])
 
     ADAPTER = HTTPAdapter(max_retries=RETRY_CONFIG)
 


### PR DESCRIPTION
It is unlikely that the retry will ever be outside of the window that raised the 429.