### PR TITLE
Support multiple authenticated users in the same environment

### DIFF
--- a/descarteslabs/__init__.py
+++ b/descarteslabs/__init__.py
@@ -16,7 +16,7 @@
 
 __version__ = "0.4.4"
 from .auth import Auth
-descartes_auth = Auth()
+descartes_auth = Auth.from_environment_or_token_json()
 
 from .services.metadata import Metadata
 from .services.places import Places

--- a/descarteslabs/auth/__init__.py
+++ b/descarteslabs/auth/__init__.py
@@ -179,6 +179,6 @@ class Auth:
 
 
 if __name__ == '__main__':
-    auth = Auth()
+    auth = Auth.from_environment_or_token_json()
 
     print(auth.token)

--- a/descarteslabs/auth/__init__.py
+++ b/descarteslabs/auth/__init__.py
@@ -71,7 +71,8 @@ class Auth:
 
     @classmethod
     def from_environment_or_token_json(cls, domain="https://iam.descarteslabs.com",
-            scope=None, leeway=500, token_info_path=DEFAULT_TOKEN_INFO_PATH):
+                                       scope=None, leeway=500,
+                                       token_info_path=DEFAULT_TOKEN_INFO_PATH):
         """
         Creates an Auth object from environment variables CLIENT_ID, CLIENT_SECRET,
         JWT_TOKEN if they are set, or else from a JSON file at the given path.
@@ -92,7 +93,7 @@ class Auth:
         jwt_token = os.environ.get('JWT_TOKEN', token_info.get('jwt_token', None))
 
         return cls(domain=domain, scope=scope, leeway=leeway, token_info_path=token_info_path,
-            client_id=client_id, client_secret=client_secret, jwt_token=jwt_token)
+                   client_id=client_id, client_secret=client_secret, jwt_token=jwt_token)
 
     @property
     def token(self):

--- a/descarteslabs/auth/__init__.py
+++ b/descarteslabs/auth/__init__.py
@@ -80,6 +80,7 @@ class Auth:
         :param leeway: JWT expiration leeway
         :param token_info_path: path to a JSON file optionally holding auth information
         """
+        token_info = {}
         try:
             with open(token_info_path) as fp:
                 token_info = json.load(fp)

--- a/descarteslabs/scripts/parser/auth.py
+++ b/descarteslabs/scripts/parser/auth.py
@@ -20,13 +20,13 @@ import json
 import six
 from six.moves import input
 
-from descarteslabs.auth import Auth, base64url_decode
+from descarteslabs.auth import Auth, base64url_decode, DEFAULT_TOKEN_INFO_PATH
 
 import descarteslabs as dl
 
 
 def auth_handler(args):
-    auth = Auth()
+    auth = Auth.from_environment_or_token_json()
 
     if args.command == 'login':
 
@@ -41,22 +41,20 @@ def auth_handler(args):
 
             token_info = json.loads(base64url_decode(s).decode('utf-8'))
 
-            path = os.path.join(os.path.expanduser("~"), '.descarteslabs')
+            path = os.path.dirname(DEFAULT_TOKEN_INFO_PATH)
 
             if not os.path.exists(path):
                 os.makedirs(path)
 
             os.chmod(path, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
 
-            file = os.path.join(os.path.expanduser("~"), '.descarteslabs', 'token_info.json')
-
-            with open(file, 'w+') as fp:
+            with open(DEFAULT_TOKEN_INFO_PATH, 'w+') as fp:
                 json.dump(token_info, fp)
 
-            os.chmod(file, stat.S_IRUSR | stat.S_IWUSR)
+            os.chmod(DEFAULT_TOKEN_INFO_PATH, stat.S_IRUSR | stat.S_IWUSR)
 
             # Get a fresh Auth token
-            auth = dl.Auth()
+            auth = dl.Auth.from_environment_or_token_json()
             dl.metadata.auth = auth
             keys = dl.metadata.keys()
 

--- a/descarteslabs/services/metadata.py
+++ b/descarteslabs/services/metadata.py
@@ -32,7 +32,7 @@ class Metadata(Service):
     TIMEOUT = (9.5, 120)
     """Image Metadata Service"""
 
-    def __init__(self, url=None, token=None):
+    def __init__(self, url=None, token=None, auth=dl.descartes_auth):
         """The parent Service class implements authentication and exponential
         backoff/retry. Override the url parameter to use a different instance
         of the backing service.
@@ -42,7 +42,7 @@ class Metadata(Service):
             url = os.environ.get("DESCARTESLABS_METADATA_URL",
                                  "https://platform-services.descarteslabs.com/metadata/v1")
 
-        Service.__init__(self, url, token)
+        Service.__init__(self, url, token, auth)
 
     def sources(self):
         """Get a list of image sources.

--- a/descarteslabs/services/places.py
+++ b/descarteslabs/services/places.py
@@ -19,13 +19,14 @@ from cachetools import TTLCache, cachedmethod
 from cachetools.keys import hashkey
 from .service import Service
 from six import string_types
+import descarteslabs
 
 
 class Places(Service):
     TIMEOUT = (9.5, 360)
     """Places and statistics service https://iam.descarteslabs.com/service/waldo"""
 
-    def __init__(self, url=None, token=None, maxsize=10, ttl=600):
+    def __init__(self, url=None, token=None, auth=descarteslabs.descartes_auth, maxsize=10, ttl=600):
         """The parent Service class implements authentication and exponential
         backoff/retry. Override the url parameter to use a different instance
         of the backing service.
@@ -33,7 +34,7 @@ class Places(Service):
         if url is None:
             url = os.environ.get("DESCARTESLABS_PLACES_URL", "https://platform-services.descarteslabs.com/waldo/v1")
 
-        Service.__init__(self, url, token)
+        Service.__init__(self, url, token, auth)
         self.cache = TTLCache(maxsize, ttl)
 
     def placetypes(self):

--- a/descarteslabs/services/raster.py
+++ b/descarteslabs/services/raster.py
@@ -18,6 +18,7 @@ from io import BytesIO
 import json
 import warnings
 
+import descarteslabs
 from descarteslabs.addons import numpy as np
 from descarteslabs.utilities import as_json_string
 from .service import Service
@@ -35,7 +36,7 @@ class Raster(Service):
     """Raster"""
     TIMEOUT = (9.5, 300)
 
-    def __init__(self, url=None, token=None):
+    def __init__(self, url=None, token=None, auth=descarteslabs.descartes_auth):
         """The parent Service class implements authentication and exponential
         backoff/retry. Override the url parameter to use a different instance
         of the backing service.
@@ -44,7 +45,7 @@ class Raster(Service):
         if url is None:
             url = os.environ.get("DESCARTESLABS_RASTER_URL", "https://platform-services.descarteslabs.com/raster/v1")
 
-        Service.__init__(self, url, token)
+        Service.__init__(self, url, token, auth)
 
     def get_bands_by_key(self, key):
         """

--- a/descarteslabs/services/service.py
+++ b/descarteslabs/services/service.py
@@ -65,8 +65,8 @@ class Service:
 
     ADAPTER = HTTPAdapter(max_retries=RETRY_CONFIG)
 
-    def __init__(self, url, token):
-        self.auth = descarteslabs.descartes_auth
+    def __init__(self, url, token, auth):
+        self.auth = auth
         self.base_url = url
         if token:
             self.auth._token = token

--- a/descarteslabs/tests/test_auth.py
+++ b/descarteslabs/tests/test_auth.py
@@ -21,7 +21,7 @@ import json
 class TestAuth(unittest.TestCase):
     def test_get_token(self):
         # get a jwt
-        auth = Auth()
+        auth = Auth.from_environment_or_token_json()
         self.assertIsNotNone(auth.token)
 
         # validate the jwt


### PR DESCRIPTION
Properly injects Auth objects into services and makes the JSON token file location configurable.

This breaks backwards-compatibility for instantiating the Auth class. Generally speaking, nobody would have had a reason to directly use the Auth class, so I feel ok about it. If somebody runs into a problem with this, they can mechanically replace any call to `Auth()` with a call to `Auth.from_environment_or_token_json()`.