### PR TITLE
Fix "logititude" typo in DLTile doc

### DIFF
--- a/docs/DLTiles.ipynb
+++ b/docs/DLTiles.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3c03d0081bf2c5b72b523391ae7f6b6d78c59e2494bef36ef94c056aea6f1fbf
-size 5473675
+oid sha256:6315886dd5c0b8ba62624eae46500a561c963d3bd613cd212fc7a22f4a15f0c0
+size 5473674


### PR DESCRIPTION
Actual diff is:

```
11c11
<     "When working with satellite imagery it can be challening to apply an analysis over a large area. In order to make this easier to do we have created DLTiles in our platform. For a region defined by geojson or latitude and logititude the platform will derive a list of tiles. These tiles will be the same across various imagery sources allowing you to easily work with data from different satellites. The tiles are projected in UTM and support whatever resolution you request.\n",
---
>     "When working with satellite imagery it can be challening to apply an analysis over a large area. In order to make this easier to do we have created DLTiles in our platform. For a region defined by geojson or latitude and longitude the platform will derive a list of tiles. These tiles will be the same across various imagery sources allowing you to easily work with data from different satellites. The tiles are projected in UTM and support whatever resolution you request.\n",
```