### PR TITLE
Allow use of old token until actually past exp.

### DIFF
--- a/descarteslabs/auth/__init__.py
+++ b/descarteslabs/auth/__init__.py
@@ -107,7 +107,7 @@ class Auth:
             if now + self.leeway > exp:
                 try:
                     self._get_token()
-                except AuthError, e:
+                except AuthError as e:
                     # Unable to refresh, raise if now > exp
                     if now > exp:
                         raise e

--- a/descarteslabs/auth/__init__.py
+++ b/descarteslabs/auth/__init__.py
@@ -105,7 +105,12 @@ class Auth:
         if exp is not None:
             now = (datetime.datetime.utcnow() - datetime.datetime(1970, 1, 1)).total_seconds()
             if now + self.leeway > exp:
-                self._get_token()
+                try:
+                    self._get_token()
+                except AuthError, e:
+                    # Unable to refresh, raise if now > exp
+                    if now > exp:
+                        raise e
 
         return self._token
 


### PR DESCRIPTION
This way if a token can't be refreshed it can still be used
until it isn't valid anymore.