### PR TITLE
Break out separate metadata generator methods with consistent naming

### DIFF
--- a/descarteslabs/tests/test_metadata.py
+++ b/descarteslabs/tests/test_metadata.py
@@ -166,8 +166,8 @@ class TestMetadata(unittest.TestCase):
         self.assertIn('items', r)
         self.assertEqual(len(r['items']), 1)
 
-    def test_features(self):
-        r = self.instance.features(start_time='2016-07-06', end_time='2016-07-07', sat_id='LANDSAT_8', batch_size=10)
+    def test_iter_search(self):
+        r = self.instance.iter_search(start_time='2016-07-06', end_time='2016-07-07', sat_id='LANDSAT_8', batch_size=10)
         first_21 = itertools.islice(r, 21)
         self.assertGreater(len(list(first_21)), 0)
 


### PR DESCRIPTION
Renaming `features` to `iter_search` but still preserving the older
name.