### PR TITLE
Remove Deprecated Endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ Changelog
 =========
 
 ## [Unreleased]
-## [0.7.0] - 2018-01-2
+## [0.8.0] - 2018-02-08
+### Changed
+- Removed deprecated searching by const_id
+- Removed deprecated raster band methods
+
+## [0.7.0] - 2018-01-24
 ### Changed
 - Reorganization into a client submodule
 
@@ -188,7 +193,8 @@ metadata.features for iterating over large search results
 ### Added
 - Initial release of client library
 
-[Unreleased]: https://github.com/descarteslabs/descarteslabs-python/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/descarteslabs/descarteslabs-python/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/descarteslabs/descarteslabs-python/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/descarteslabs/descarteslabs-python/compare/v0.6.2...v0.7.0
 [0.6.2]: https://github.com/descarteslabs/descarteslabs-python/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/descarteslabs/descarteslabs-python/compare/v0.6.0...v0.6.1

--- a/descarteslabs/client/auth/auth.py
+++ b/descarteslabs/client/auth/auth.py
@@ -74,23 +74,26 @@ class Auth:
         self.token_info_path = token_info_path
 
         token_info = {}
-        try:
-            if self.token_info_path:
+        if self.token_info_path:
+            try:
                 with open(self.token_info_path) as fp:
                     token_info = json.load(fp)
-        except (IOError, ValueError):
-            pass
+            except (IOError, ValueError):
+                pass
 
         self.client_id = client_id if client_id else os.environ.get('CLIENT_ID', token_info.get('client_id', None))
         self.client_secret = client_secret if client_secret else os.environ.get('CLIENT_SECRET', token_info.get(
             'client_secret', None))
         self._token = jwt_token if jwt_token else os.environ.get('JWT_TOKEN', token_info.get('jwt_token', None))
 
-        client_id_changed = token_info.get('client_id', None) != self.client_id
-        client_secret_changed = token_info.get('client_secret', None) != self.client_secret
+        if token_info:
+            # If the token was read from a path but environment variables were set, we may need
+            # to reset the token.
+            client_id_changed = token_info.get('client_id', None) != self.client_id
+            client_secret_changed = token_info.get('client_secret', None) != self.client_secret
 
-        if client_id_changed or client_secret_changed:
-            self._token = None
+            if client_id_changed or client_secret_changed:
+                self._token = None
 
         self._namespace = None
 

--- a/descarteslabs/client/auth/tests/test_auth.py
+++ b/descarteslabs/client/auth/tests/test_auth.py
@@ -18,6 +18,10 @@ import requests
 import json
 
 
+# flake8: noqa
+anon_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJncm91cHMiOlsicHVibGljIl0sImlzcyI6Imh0dHBzOi8vZGVzY2FydGVzbGFicy5hdXRoMC5jb20vIiwic3ViIjoiZGVzY2FydGVzfGFub24tdG9rZW4iLCJhdWQiOiJaT0JBaTRVUk9sNWdLWklweHhsd09FZng4S3BxWGYyYyIsImV4cCI6OTk5OTk5OTk5OSwiaWF0IjoxNDc4MjAxNDE5fQ.QL9zq5SkpO7skIy0niIxI0B92uOzZT5t1abuiJaspRI"
+
+
 class TestAuth(unittest.TestCase):
     def test_get_token(self):
         # get a jwt
@@ -34,6 +38,10 @@ class TestAuth(unittest.TestCase):
     def test_get_namespace(self):
         auth = Auth.from_environment_or_token_json()
         self.assertIsNotNone(auth.namespace)
+
+    def test_init_token_no_path(self):
+        auth = Auth(jwt_token=anon_token, token_info_path=None, client_id="foo")
+        self.assertEquals(anon_token, auth._token)
 
 
 if __name__ == '__main__':

--- a/descarteslabs/client/scripts/cli.py
+++ b/descarteslabs/client/scripts/cli.py
@@ -40,7 +40,6 @@ metadata_parser.add_argument('command', choices=['sources', 'summary', 'search',
 metadata_parser.add_argument('argument', nargs='?')
 metadata_parser.add_argument('-url', help='The url of the service')
 metadata_parser.add_argument('-place', help='A slug for a named place')
-metadata_parser.add_argument('-const_id', default=None, help='Constellation ID', nargs='+')
 metadata_parser.add_argument('-start_time', help='Start of valid date/time range (inclusive)')
 metadata_parser.add_argument('-end_time', help='End of valid date/time range (inclusive)')
 metadata_parser.add_argument('-geom', help='Region of interest as GeoJSON or WKT')

--- a/descarteslabs/client/services/metadata/cli.py
+++ b/descarteslabs/client/services/metadata/cli.py
@@ -35,8 +35,6 @@ def metadata_handler(args):
     if args.command == 'summary':
         if args.place:
             kwargs['place'] = args.place
-        if args.const_id:
-            kwargs['const_id'] = args.const_id
         if args.start_time:
             kwargs['start_time'] = args.start_time
         if args.end_time:
@@ -53,8 +51,6 @@ def metadata_handler(args):
     if args.command == 'search':
         if args.place:
             kwargs['place'] = args.place
-        if args.const_id:
-            kwargs['const_id'] = args.const_id
         if args.start_time:
             kwargs['start_time'] = args.start_time
         if args.end_time:
@@ -75,8 +71,6 @@ def metadata_handler(args):
     if args.command == 'keys':
         if args.place:
             kwargs['place'] = args.place
-        if args.const_id:
-            kwargs['const_id'] = args.const_id
         if args.start_time:
             kwargs['start_time'] = args.start_time
         if args.end_time:

--- a/descarteslabs/client/services/metadata/tests/test_metadata.py
+++ b/descarteslabs/client/services/metadata/tests/test_metadata.py
@@ -14,7 +14,6 @@
 
 import itertools
 import unittest
-from warnings import catch_warnings
 
 from descarteslabs.client.services.metadata import Metadata, properties as p
 from descarteslabs.client.exceptions import NotFoundError
@@ -61,10 +60,6 @@ class TestMetadata(unittest.TestCase):
         for feature in r['features']:
             self.assertEqual(feature['properties']['cloud_fraction'], 0.0)
 
-    def test_translate_to_product(self):
-        r = self.instance.translate('l8')
-        self.assertEqual(r['product'], 'landsat:LC08:PRE:TOAR')
-
     def test_search_by_product(self):
         r = self.instance.search(start_time='2016-07-06', end_time='2016-07-07', products=['landsat:LC08:PRE:TOAR'])
         self.assertGreater(len(r['features']), 0)
@@ -102,13 +97,6 @@ class TestMetadata(unittest.TestCase):
         for feature in r['features']:
             self.assertEqual(sorted(feature['properties'].keys()), sorted(fields))
 
-    def test_const_id_search_deprecation(self):
-        with catch_warnings(record=True) as w:
-            r = self.instance.search(start_time='2016-07-06', end_time='2016-07-07', const_id=['l8'])
-            self.assertGreater(len(r['features']), 0)
-            self.assertEqual(len(w), 1)
-            self.assertIn('deprecated', str(w[0].message))
-
     def test_multiple_products_search(self):
         r = self.instance.search(
             start_time='2016-07-06',
@@ -133,23 +121,6 @@ class TestMetadata(unittest.TestCase):
         self.assertIn('pixels', r)
         self.assertIn('bytes', r)
         self.assertGreater(r['count'], 0)
-
-    def test_const_id_summary_deprecation(self):
-        with catch_warnings(record=True) as w:
-            r = self.instance.summary(
-                start_time='2016-07-06',
-                end_time='2016-07-07',
-                const_id=['l8'],
-                pixels=True
-            )
-            self.assertEqual(len(w), 1)
-            self.assertIn('deprecated', str(w[0].message))
-
-            self.assertIn('products', r)
-            self.assertIn('count', r)
-            self.assertIn('pixels', r)
-            self.assertIn('bytes', r)
-            self.assertGreater(r['count'], 0)
 
     def test_summary_part(self):
         r = self.instance.summary(
@@ -215,9 +186,6 @@ class TestMetadata(unittest.TestCase):
 
     def test_get_bands_by_key(self):
         self.instance.get_bands_by_key('meta_LC80270312016188_v1')
-
-    def test_get_bands_by_const(self):
-        self.instance.get_bands_by_constellation('L8')
 
     def test_expr_serialization(self):
         q = ((0.1 < p.cloud_fraction <= 0.2) & (p.sat_id == "f00b")) | (p.sat_id == "usa-245")

--- a/descarteslabs/client/services/raster/raster.py
+++ b/descarteslabs/client/services/raster/raster.py
@@ -15,7 +15,6 @@
 import json
 import os
 import struct
-import warnings
 from io import BytesIO
 
 import six
@@ -25,11 +24,6 @@ from descarteslabs.client.auth import Auth
 from descarteslabs.client.services.places import Places
 from descarteslabs.client.services.service.service import Service
 from descarteslabs.client.exceptions import ServerError
-
-RASTER_BANDS_WARNING = """
-Band retrieval through the raster service is deprecated, and will be
-removed eventually. Use the corresponding methods on the metadata
-service instead."""
 
 
 def as_json_string(str_or_dict):
@@ -87,36 +81,10 @@ class Raster(Service):
         backoff/retry. Override the url parameter to use a different instance
         of the backing service.
         """
-        warnings.simplefilter('always', DeprecationWarning)
         if url is None:
             url = os.environ.get("DESCARTESLABS_RASTER_URL", "https://platform.descarteslabs.com/raster/v1")
 
         Service.__init__(self, url, token, auth)
-
-    def get_bands_by_key(self, key):
-        """
-        For a given source id, return the available bands.
-
-        :param str key: A :class:`Metadata` identifiers.
-
-        :return: A dictionary of band entries and their metadata.
-        """
-        warnings.warn(RASTER_BANDS_WARNING, DeprecationWarning)
-        r = self.session.get('/bands/key/%s' % key)
-
-        return r.json()
-
-    def get_bands_by_constellation(self, const):
-        """
-        For a given constellation id, return the available bands.
-
-        :param str const: A constellation name/abbreviation.
-
-        :return: A dictionary of band entries and their metadata.
-        """
-        warnings.warn(RASTER_BANDS_WARNING, DeprecationWarning)
-        r = self.session.get('/bands/constellation/%s' % const)
-        return r.json()
 
     def dltiles_from_shape(self, resolution, tilesize, pad, shape):
         """
@@ -138,11 +106,11 @@ class Raster(Service):
             >>> iowa = Places().shape("north-america_united-states_iowa")
             >>> tiles = Raster().dltiles_from_shape(30.0, 2048, 16, iowa)
             >>> pprint(tiles['features'][0])
-            {'geometry': {'coordinates': [[[-96.81264975325391, 41.04520331997488],
-                                           [-96.07101667769165, 41.02873098011615],
-                                           [-96.04576296033328, 41.590072611375206],
-                                           [-96.79377566762062, 41.606871549447824],
-                                           [-96.81264975325391, 41.04520331997488]]],
+            {'geometry': {'coordinates': [[[-96.81264975325402, 41.045203319986356],
+                                           [-96.07101667769108, 41.02873098016475],
+                                           [-96.04576296033223, 41.59007261142797],
+                                           [-96.79377566762066, 41.60687154946031],
+                                           [-96.81264975325402, 41.045203319986356]]],
                           'type': 'Polygon'},
              'properties': {'cs_code': 'EPSG:32614',
                             'key': '2048:16:30.0:14:3:74',
@@ -185,11 +153,11 @@ class Raster(Service):
             >>> from descarteslabs.client.services import Raster
             >>> from pprint import pprint
             >>> pprint(Raster().dltile_from_latlon(45, 60, 15.0, 1024, 16))
-            {'geometry': {'coordinates': [[[59.88428127486957, 44.89851158838881],
-                                           [60.084634558186266, 44.903806716073376],
-                                           [60.07740397456606, 45.04621255053833],
-                                           [59.87655568676388, 45.04089121582091],
-                                           [59.88428127486957, 44.89851158838881]]],
+            {'geometry': {'coordinates': [[[59.88428127486419, 44.89851158847289],
+                                           [60.08463455818353, 44.90380671613201],
+                                           [60.077403974563175, 45.046212550598135],
+                                           [59.87655568675822, 45.040891215906676],
+                                           [59.88428127486419, 44.89851158847289]]],
                           'type': 'Polygon'},
             'properties': {'cs_code': 'EPSG:32641',
                            'key': '1024:16:15.0:41:-16:324',
@@ -225,11 +193,11 @@ class Raster(Service):
             >>> from descarteslabs.client.services import Raster
             >>> from pprint import pprint
             >>> pprint(Raster().dltile("1024:16:15.0:41:-16:324"))
-            {'geometry': {'coordinates': [[[59.88428127486957, 44.89851158838881],
-                                           [60.084634558186266, 44.903806716073376],
-                                           [60.07740397456606, 45.04621255053833],
-                                           [59.87655568676388, 45.04089121582091],
-                                           [59.88428127486957, 44.89851158838881]]],
+            {'geometry': {'coordinates': [[[59.88428127486419, 44.89851158847289],
+                                           [60.08463455818353, 44.90380671613201],
+                                           [60.077403974563175, 45.046212550598135],
+                                           [59.87655568675822, 45.040891215906676],
+                                           [59.88428127486419, 44.89851158847289]]],
                           'type': 'Polygon'},
              'properties': {'cs_code': 'EPSG:32641',
                             'key': '1024:16:15.0:41:-16:324',
@@ -246,30 +214,6 @@ class Raster(Service):
         r = self.session.get('/dlkeys/%s' % key)
 
         return r.json()
-
-    def dlkeys_from_shape(self, resolution, tilesize, pad, shape):
-        """
-        Deprecated. See dltiles_from_shape
-        """
-        warnings.warn("dlkey methods have been renamed to dltile",
-                      DeprecationWarning, stacklevel=2)
-        return self.dltiles_from_shape(resolution, tilesize, pad, shape)
-
-    def dlkey_from_latlon(self, lat, lon, resolution, tilesize, pad):
-        """
-        Deprecated. See dltile_from_latlon
-        """
-        warnings.warn("dlkey methods have been renamed to dltile",
-                      DeprecationWarning, stacklevel=2)
-        return self.dltile_from_latlon(lat, lon, resolution, tilesize, pad)
-
-    def dlkey(self, key):
-        """
-        Deprecated. See dltile
-        """
-        warnings.warn("dlkey methods have been renamed to dltile",
-                      DeprecationWarning, stacklevel=2)
-        return self.dltile(key)
 
     def raster(
             self,

--- a/descarteslabs/client/services/raster/tests/test_raster.py
+++ b/descarteslabs/client/services/raster/tests/test_raster.py
@@ -17,7 +17,6 @@ import tempfile
 import shutil
 import unittest
 import json
-from warnings import catch_warnings
 
 import descarteslabs.client.addons as addons
 from descarteslabs.client.addons import numpy as np
@@ -200,22 +199,6 @@ class TestRaster(unittest.TestCase):
         self.assertTrue("files" in r)
         self.assertIsNotNone(r['files']['meta_LC80270312016188_v1_red-green-blue-alpha.png'])
 
-    def test_get_bands_by_key(self):
-        with catch_warnings(record=True) as w:
-            r = self.raster.get_bands_by_key('meta_LC80270312016188_v1')
-            self.assertEqual(len(w), 1)
-            for band in ['red', 'green', 'blue', 'alpha', 'swir1', 'swir2', 'ndvi',
-                         'ndwi', 'evi', 'cirrus']:
-                self.assertTrue(band in r)
-
-    def test_landsat8_bands(self):
-        with catch_warnings(record=True) as w:
-            r = self.raster.get_bands_by_constellation('L8')
-            self.assertEqual(len(w), 1)
-            for band in ['red', 'green', 'blue', 'alpha', 'swir1', 'swir2', 'ndvi',
-                         'ndwi', 'evi', 'cirrus']:
-                self.assertTrue(band in r)
-
     def test_dltiles_from_place(self):
         iowa = self.places.shape('north-america_united-states_iowa', geom='low')
         iowa_geom = iowa['geometry']
@@ -251,26 +234,6 @@ class TestRaster(unittest.TestCase):
         self.assertEqual(arr.shape[0], 256 + 2 * 16)
         self.assertEqual(arr.shape[1], 256 + 2 * 16)
         self.assertEqual(arr.shape[2], 4)
-
-    def test_dlkeys_from_place(self):
-        iowa = self.places.shape('north-america_united-states_iowa', geom='low')
-        iowa_geom = iowa['geometry']
-        with catch_warnings(record=True) as w:
-            dlkeys_geojson = self.raster.dlkeys_from_shape(30.0, 2048, 16, iowa_geom)
-            self.assertEqual(len(dlkeys_geojson['features']), 58)
-            self.assertEqual(DeprecationWarning, w[0].category)
-
-    def test_dlkeys_from_latlon(self):
-        with catch_warnings(record=True) as w:
-            dlkey_geojson = self.raster.dlkey_from_latlon(45.0, -90.0, 30.0, 2048, 16)
-            self.assertEqual(dlkey_geojson['properties']['key'], "2048:16:30.0:16:-4:81")
-            self.assertEqual(DeprecationWarning, w[0].category)
-
-    def test_dlkey(self):
-        with catch_warnings(record=True) as w:
-            dlkey_geojson = self.raster.dlkey("2048:16:30.0:16:-4:81")
-            self.assertEqual(dlkey_geojson['properties']['key'], "2048:16:30.0:16:-4:81")
-            self.assertEqual(DeprecationWarning, w[0].category)
 
 
 if __name__ == "__main__":

--- a/descarteslabs/client/version.py
+++ b/descarteslabs/client/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/docs/DLTiles.rst
+++ b/docs/DLTiles.rst
@@ -68,7 +68,7 @@ unmasked pixels giving us a total number of pixels that are land.
     # get the shape of Newport County
     shape = dl.places.shape(aoi['slug'], geom='low')
     # get ids for imagery
-    feature_collection = dl.metadata.search(const_id='L8', start_time='2016-06-01',
+    feature_collection = dl.metadata.search(products=['landsat:LC08:PRE:TOAR'], start_time='2016-06-01',
                                             end_time='2016-06-30', limit=10, place=aoi['slug'])
     ids = [f['id'] for f in feature_collection['features']]
 
@@ -214,7 +214,7 @@ the area of Rhode Island.
         counter = 0;
         for tile in tiles['features']:
             images = dl.metadata.search(
-                                    const_id=["L8"],
+                                    products=["landsat:LC08:PRE:TOAR"],
                                     start_time=date[0],
                                     end_time=date[1],
                                     geom=json.dumps(tile['geometry']),
@@ -367,7 +367,7 @@ with 60 meter resolution instead if 30.
         counter = 0;
         for tile in tiles['features']:
             images = dl.metadata.search(
-                                    const_id=["L8"],
+                                    products=["landsat:LC08:PRE:TOAR"],
                                     start_time=date[0],
                                     end_time=date[1],
                                     geom=json.dumps(tile['geometry']),

--- a/docs/land_cover_demo.rst
+++ b/docs/land_cover_demo.rst
@@ -138,11 +138,11 @@ any data from MODIS acquired over 2016 as long as the scene is less than
 
 .. code:: ipython2
 
-    # use const_id, start_time, end_time, geom, and cloud_fraction
+    # use products, start_time, end_time, geom, and cloud_fraction
     # parameters to limit our imagery search to
 
     images = dl.metadata.search(
-                                    const_id=["MO", "MY"],
+                                    products=["modis:09:CREFL"],
                                     start_time='2016-01-01',
                                     end_time='2016-12-31',
                                     geom=dltile['geometry'],

--- a/docs/wildfire_assessment_demo.rst
+++ b/docs/wildfire_assessment_demo.rst
@@ -55,7 +55,7 @@ Retreive imagery
 
     # Check for imagery before the start date of July 22nd
 
-    feature_collection = dl.metadata.search(const_id='L8', start_time='2016-07-22', end_time='2016-07-31',
+    feature_collection = dl.metadata.search(products=['landsat:LC08:PRE:TOAR'], start_time='2016-07-22', end_time='2016-07-31',
                                             limit=10, place=aoi['slug'])
     # As the variable name implies, this returns a FeatureCollection GeoJSON dictionary.
     # Its 'features' are the available scenes.
@@ -66,7 +66,7 @@ Retreive imagery
     print([f['id'] for f in feature_collection['features']])
 
     # Now check for imagery in late October, i.e., towards the end of the fire
-    feature_collection = dl.metadata.search(const_id='L8', start_time='2016-10-15', end_time='2016-10-31',
+    feature_collection = dl.metadata.search(products=['landsat:LC08:PRE:TOAR'], start_time='2016-10-15', end_time='2016-10-31',
                                             limit=10, place=aoi['slug'])
 
     print(len(feature_collection['features']))
@@ -167,7 +167,7 @@ Retreive imagery
         iax.get_yaxis().set_ticks([])
 
     for i, timewindow in enumerate(times):
-        feature_collection = dl.metadata.search(const_id='L8', start_time=timewindow[0], end_time=timewindow[1],
+        feature_collection = dl.metadata.search(products=['landsat:LC08:PRE:TOAR'], start_time=timewindow[0], end_time=timewindow[1],
                                             limit=10, place=aoi['slug'])
         ids = [f['id'] for f in feature_collection['features']]
         arr, meta = dl.raster.ndarray(
@@ -201,7 +201,7 @@ Obtain the Delta Normalized Burn Ratio
     # We will request the raw band rasters scaled now to 10000 (100% TOAR) to obtain a correct analytic value
 
     # Get pre-fire NBR
-    feature_collection = dl.metadata.search(const_id='L8', start_time='2016-07-01', end_time='2016-07-20',
+    feature_collection = dl.metadata.search(products=['landsat:LC08:PRE:TOAR'], start_time='2016-07-01', end_time='2016-07-20',
                                             limit=10, place=aoi['slug'])
     ids = [f['id'] for f in feature_collection['features']]
     arr, meta = dl.raster.ndarray(
@@ -217,7 +217,7 @@ Obtain the Delta Normalized Burn Ratio
     prenbr = (arr[:,:,1]-arr[:,:,0])/(arr[:,:,1]+arr[:,:,0]+1e-9)
 
     # Get post-fire NBR
-    feature_collection = dl.metadata.search(const_id='L8', start_time='2016-10-15', end_time='2016-10-31',
+    feature_collection = dl.metadata.search(products=['landsat:LC08:PRE:TOAR'], start_time='2016-10-15', end_time='2016-10-31',
                                             limit=10, place=aoi['slug'])
     ids = [f['id'] for f in feature_collection['features']]
     arr, meta = dl.raster.ndarray(


### PR DESCRIPTION
- The client no longer supports `const_id` arguments.
- Raster no longer provides band information. This information should be obtained through metadata.
- Includes fix for proj4 accuracy. 

GitOrigin-RevId: ba03d47c2009a455d488d411d0d957285ec9f8e1